### PR TITLE
Catch exceptions in Show-ToastMessage

### DIFF
--- a/chocolatey-misc-helpers.extension/extensions/Show-ToastMessage.ps1
+++ b/chocolatey-misc-helpers.extension/extensions/Show-ToastMessage.ps1
@@ -8,35 +8,48 @@
 
 function Show-ToastMessage($MessageLine1, $MessageLine2){
 
-if (!(Test-Path "$ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico")){
-     [System.Reflection.Assembly]::LoadWithPartialName('System.Drawing')  | Out-Null
-     [System.Drawing.Icon]::ExtractAssociatedIcon("$env:ChocolateyInstall\choco.exe").ToBitmap().Save("$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico")
-}
+    if (!(Test-Path "$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico")){
+        [System.Reflection.Assembly]::LoadWithPartialName('System.Drawing')  | Out-Null
+        [System.Drawing.Icon]::ExtractAssociatedIcon("$env:ChocolateyInstall\choco.exe").ToBitmap().Save("$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico")
+    }
 
-if (Get-Module -ListAvailable -Name BurntToast -ErrorAction SilentlyContinue){
-     New-BurntToastNotification -Text "Chocolatey ($env:packageName)", "$MessageLine1", "$MessageLine2" -AppLogo "$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico"
-   } else {
-     $app = '{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe'
-     [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-     $Template = [Windows.UI.Notifications.ToastTemplateType]::ToastImageAndText01
-     #Gets the Template XML so we can manipulate the values
-     [xml]$ToastTemplate = ([Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent($Template).GetXml())
-     [xml]$ToastTemplate = @"
+    if (Get-Module -ListAvailable -Name BurntToast -ErrorAction SilentlyContinue){
+        New-BurntToastNotification -Text "Chocolatey ($env:packageName)", "$MessageLine1", "$MessageLine2" -AppLogo "$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico"
+    } else {
+        try {
+            $app = '{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe'
+            [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+            $Template = [Windows.UI.Notifications.ToastTemplateType]::ToastImageAndText01
+            #Gets the Template XML so we can manipulate the values
+            [xml]$ToastTemplate = ([Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent($Template).GetXml())
+            [xml]$ToastTemplate = @"
 <toast launch="app-defined-string">
   <visual>
     <binding template="ToastGeneric">
-      <text>Chocolatey ($env:packageName)</text>	
+      <text>Chocolatey ($env:packageName)</text>
       <text>$MessageLine1</text>
       <text>$MessageLine2</text>
-	  <branding>logo</branding>
-	  <image placement="appLogoOverride" src="$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico"/>
+          <branding>logo</branding>
+          <image placement="appLogoOverride" src="$env:ChocolateyInstall\extensions\chocolatey-misc-helpers\choco.ico"/>
     </binding>
   </visual>
 </toast>
 "@
-     $ToastXml = New-Object -TypeName Windows.Data.Xml.Dom.XmlDocument
-     $ToastXml.LoadXml($ToastTemplate.OuterXml)
-     $notify = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($app) 
-     $notify.Show($ToastXml)
+            $ToastXml = New-Object -TypeName Windows.Data.Xml.Dom.XmlDocument
+            $ToastXml.LoadXml($ToastTemplate.OuterXml)
+            $notify = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($app) 
+            $notify.Show($ToastXml)
+        } catch {
+            [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") | Out-Null
+            $notify = New-Object System.Windows.Forms.NotifyIcon
+         
+            $notify.Icon=[System.Drawing.Icon]::ExtractAssociatedIcon("$env:ChocolateyInstall\choco.exe")
+            $notify.BalloonTipIcon="Info"
+            $notify.BalloonTipTitle="$MessageLine1"
+            $notify.BalloonTipText="$MessageLine2"
+         
+            $notify.Visible=$True
+            $notify.ShowBalloonTip(10000)
+        }
     }
 }


### PR DESCRIPTION
This catches the "Unable to find type
Windows.UI.Notifications.ToastNotificationManager" error and tries a
balloon tip instead.

As per comments on: http://disq.us/p/1ui4v33

This works for me on Window 7 Pro 6.1.7601 Service Pack 1 Build 7601
but is not tested on Windows 10, etc.